### PR TITLE
Added relative directory support for compositions

### DIFF
--- a/cookie_composer/composition.py
+++ b/cookie_composer/composition.py
@@ -215,6 +215,8 @@ def read_composition(path_or_url: Union[str, Path]) -> Composition:
     Raises:
         MissingCompositionFileError: Raised when it can not access the configuration file.
     """
+    import urllib.parse
+
     import fsspec
     from ruamel.yaml import YAML
 
@@ -224,6 +226,9 @@ def read_composition(path_or_url: Union[str, Path]) -> Composition:
         with of as f:
             contents = list(yaml.load_all(f))
             templates = [LayerConfig(**doc) for doc in contents]
+        for tmpl in templates:
+            tmpl.template = urllib.parse.urljoin(str(path_or_url), str(tmpl.template))
+
         return Composition(layers=templates)
     except FileNotFoundError as e:
         raise MissingCompositionFileError(path_or_url) from e

--- a/tests/fixtures/multi-template.yaml
+++ b/tests/fixtures/multi-template.yaml
@@ -1,5 +1,5 @@
-template: tests/fixtures/template1
+template: template1
 ---
-template: tests/fixtures/template2
+template: template2
 context:
   project_slug: "{{ cookiecutter.repo_slug }}"

--- a/tests/fixtures/relative-multi-template.yaml
+++ b/tests/fixtures/relative-multi-template.yaml
@@ -1,0 +1,7 @@
+template: .
+directory: template1
+---
+template: .
+directory: template2
+context:
+  project_slug: "{{ cookiecutter.repo_slug }}"

--- a/tests/test_commands/test_create.py
+++ b/tests/test_commands/test_create.py
@@ -20,3 +20,12 @@ def test_render_composition(fixtures_path, tmp_path):
     rendered_items = {item.name for item in os.scandir(project_path)}
 
     assert rendered_items == {"ABOUT.md", "README.md", "requirements.txt", ".composition.yaml"}
+
+
+def test_render_relative_composition(fixtures_path, tmp_path):
+    """Test rendering a composition file."""
+    template_path = fixtures_path / "relative-multi-template.yaml"
+    project_path = create.create_cmd(str(template_path), tmp_path, no_input=True)
+    rendered_items = {item.name for item in os.scandir(project_path)}
+
+    assert rendered_items == {"ABOUT.md", "README.md", "requirements.txt", ".composition.yaml"}

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 
 import pytest
-from pytest import param
 
 from cookie_composer import composition
 from cookie_composer.composition import LayerConfig
@@ -12,15 +11,23 @@ def test_multiple_templates(fixtures_path):
     filepath = fixtures_path / "multi-template.yaml"
     comp = composition.read_composition(filepath)
     assert len(comp.layers) == 2
-    assert comp.layers[0].template == "tests/fixtures/template1"
-    assert comp.layers[1].template == "tests/fixtures/template2"
+    assert comp.layers[0].template == str(fixtures_path / "template1")
+    assert comp.layers[1].template == str(fixtures_path / "template2")
+
+
+def test_relative_templates(fixtures_path):
+    filepath = fixtures_path / "relative-multi-template.yaml"
+    comp = composition.read_composition(filepath)
+    assert len(comp.layers) == 2
+    assert comp.layers[0].template == f"{str(fixtures_path)}/"
+    assert comp.layers[1].template == f"{str(fixtures_path)}/"
 
 
 def test_single_template(fixtures_path):
     filepath = fixtures_path / "single-template.yaml"
     comp = composition.read_composition(filepath)
     assert len(comp.layers) == 1
-    assert comp.layers[0].template == "tests/fixtures/template1"
+    assert comp.layers[0].template == str(fixtures_path / "tests/fixtures/template1")
 
 
 def test_is_composition_file():
@@ -43,8 +50,8 @@ def test_empty_composition(fixtures_path):
 def test_write_composition(tmp_path):
     """Test writing out layers."""
     layers = [
-        LayerConfig(template="tests/fixtures/template1"),
-        LayerConfig(template="tests/fixtures/template2"),
+        LayerConfig(template=str(tmp_path / "tests/fixtures/template1")),
+        LayerConfig(template=str(tmp_path / "tests/fixtures/template2")),
     ]
     filepath = tmp_path / "composition.yaml"
     composition.write_composition(layers, filepath)
@@ -56,7 +63,7 @@ def test_write_composition(tmp_path):
 def test_get_composition_from_path_or_url_composition(fixtures_path: Path):
     """The paths should generate the correct Composition."""
     filepath = fixtures_path / "single-template.yaml"
-    expected = composition.Composition(layers=[LayerConfig(template="tests/fixtures/template1")])
+    expected = composition.Composition(layers=[LayerConfig(template=str(fixtures_path / "tests/fixtures/template1"))])
     assert composition.get_composition_from_path_or_url(str(filepath)) == expected
 
 


### PR DESCRIPTION
- Template paths or URLs are resolved using the path to the composition file.
- Using an absolute path or URL as a template works as before
- `.`, `..`, and relative paths (non-`/` prefixed) are resolved with `urllib.parse.urljoin`